### PR TITLE
Solution 01/execute transaction

### DIFF
--- a/src/domain/customer.ts
+++ b/src/domain/customer.ts
@@ -16,7 +16,7 @@ export class Customer {
   }
 
   withdraw(amount: number): void {
-    if (Math.abs(this.balance - amount) > this.limit)
+    if (this.balance < 0 && Math.abs(this.balance - amount) > this.limit)
       throw new Error('WITHOUT_LIMIT')
     this.balance -= amount
   }

--- a/src/domain/factories/createTransaction.factory.ts
+++ b/src/domain/factories/createTransaction.factory.ts
@@ -1,0 +1,7 @@
+import { type IInputCreateTransaction, Transaction } from '../transaction'
+
+export type ICreateTransaction = (input: IInputCreateTransaction) => Transaction
+
+export function createTransaction(input: IInputCreateTransaction): Transaction {
+  return new Transaction(input)
+}

--- a/src/domain/transaction.ts
+++ b/src/domain/transaction.ts
@@ -3,7 +3,7 @@ export enum TransactionType {
   DEBIT = 'd',
 }
 
-interface IInputCreateTransaction {
+export interface IInputCreateTransaction {
   amount: number
   type: TransactionType
   description: string

--- a/src/usecase/executeTransaction.ts
+++ b/src/usecase/executeTransaction.ts
@@ -1,5 +1,6 @@
 import { type UseCase } from '../common/useCase'
-import { Transaction, TransactionType } from '../domain/transaction'
+import { type ICreateTransaction } from '../domain/factories/createTransaction.factory'
+import { TransactionType } from '../domain/transaction'
 import { type ICustomerRepository } from '../repositories/customerRepository'
 import { type ITransactionRepository } from '../repositories/transactionRepository'
 import {
@@ -11,6 +12,7 @@ export class ExecuteTransaction
   implements UseCase<InputExecuteTransactionDto, OutputExecuteTransactionDto>
 {
   constructor(
+    private readonly createTransaction: ICreateTransaction,
     private readonly customerRepository: ICustomerRepository,
     private readonly transactionRepository: ITransactionRepository,
   ) {}
@@ -20,12 +22,13 @@ export class ExecuteTransaction
   ): Promise<OutputExecuteTransactionDto> {
     const customer = await this.customerRepository.findById(input.customerId)
     if (customer === null) throw new Error('CUSTOMER_NOT_FOUND')
-    const transaction = new Transaction({
+    const transaction = this.createTransaction({
       customerId: input.customerId,
       amount: input.amount,
       description: input.description,
       type: input.type,
     })
+    console.log({ customer, transaction })
     if (transaction.type === TransactionType.CREDIT)
       customer.deposit(input.amount)
     if (transaction.type === TransactionType.DEBIT)

--- a/tests/domain/customer.unit.ts
+++ b/tests/domain/customer.unit.ts
@@ -43,6 +43,16 @@ describe('Customer Entity', () => {
         sut.withdraw(2000)
       }).toThrow(new Error('WITHOUT_LIMIT'))
     })
+
+    test('should withdraw when result balance amount is greather than limit', () => {
+      const sut = new Customer({
+        id: 1,
+        balance: 12000,
+        limit: 10000,
+      })
+      sut.withdraw(1000)
+      expect(sut.balance).toBe(11000)
+    })
   })
 
   describe('Deposit', () => {

--- a/tests/mocks/domain/factories/createTransaction.factory.mock.ts
+++ b/tests/mocks/domain/factories/createTransaction.factory.mock.ts
@@ -1,0 +1,11 @@
+import { type ICreateTransaction } from '../../../../src/domain/factories/createTransaction.factory'
+import {
+  type IInputCreateTransaction,
+  Transaction,
+} from '../../../../src/domain/transaction'
+
+export const createTransactionMock: jest.Mocked<ICreateTransaction> = jest
+  .fn()
+  .mockImplementation(
+    (value: IInputCreateTransaction) => new Transaction(value),
+  )

--- a/tests/mocks/repositories/customerRepository.mock.ts
+++ b/tests/mocks/repositories/customerRepository.mock.ts
@@ -1,5 +1,5 @@
-import { type ICustomerRepository } from '../../src/repositories/customerRepository'
-import { Customer } from '../../src/domain/customer'
+import { type ICustomerRepository } from '../../../src/repositories/customerRepository'
+import { Customer } from '../../../src/domain/customer'
 
 export const fakeCustomerEntity = new Customer({
   id: 1,

--- a/tests/mocks/repositories/transactionRepository.mock.ts
+++ b/tests/mocks/repositories/transactionRepository.mock.ts
@@ -1,5 +1,5 @@
-import { type ITransactionRepository } from '../../src/repositories/transactionRepository'
-import { Transaction, TransactionType } from '../../src/domain/transaction'
+import { type ITransactionRepository } from '../../../src/repositories/transactionRepository'
+import { Transaction, TransactionType } from '../../../src/domain/transaction'
 
 export const fakeTransactionEntity = new Transaction({
   amount: 1000,

--- a/tests/usecase/executeTransaction.unit.ts
+++ b/tests/usecase/executeTransaction.unit.ts
@@ -3,8 +3,8 @@ import { ExecuteTransaction } from '../../src/usecase/executeTransaction'
 import {
   customerRepositoryMock,
   fakeCustomerEntity,
-} from '../mocks/customerRepository.mock'
-import { transactionRepositoryMock } from '../mocks/transactionRepository.mock'
+} from '../mocks/repositories/customerRepository.mock'
+import { transactionRepositoryMock } from '../mocks/repositories/transactionRepository.mock'
 
 describe('Execute transaction use case', () => {
   beforeEach(() => {

--- a/tests/usecase/executeTransaction.unit.ts
+++ b/tests/usecase/executeTransaction.unit.ts
@@ -1,5 +1,6 @@
-import { Transaction, TransactionType } from '../../src/domain/transaction'
+import { TransactionType } from '../../src/domain/transaction'
 import { ExecuteTransaction } from '../../src/usecase/executeTransaction'
+import { createTransactionMock } from '../mocks/domain/factories/createTransaction.factory.mock'
 import {
   customerRepositoryMock,
   fakeCustomerEntity,
@@ -8,13 +9,21 @@ import { transactionRepositoryMock } from '../mocks/repositories/transactionRepo
 
 describe('Execute transaction use case', () => {
   beforeEach(() => {
-    jest.resetModules()
+    jest.restoreAllMocks()
+  })
+  afterAll(() => {
+    jest.clearAllMocks()
   })
   const transactionRepository = transactionRepositoryMock
   const customerRepository = customerRepositoryMock
-  const sut = new ExecuteTransaction(customerRepository, transactionRepository)
+  const createTransaction = createTransactionMock
+  const sut = new ExecuteTransaction(
+    createTransaction,
+    customerRepository,
+    transactionRepository,
+  )
   const fakeInput = {
-    amount: 1000,
+    amount: 5000,
     customerId: 2,
     description: 'Ow yeah',
     type: TransactionType.CREDIT,
@@ -34,9 +43,9 @@ describe('Execute transaction use case', () => {
     await expect(sut.exec(fakeInput)).rejects.toThrow('CUSTOMER_NOT_FOUND')
   })
 
-  test.skip('should create transaction with right params', async () => {
+  test('should create transaction with right params', async () => {
     await sut.exec(fakeInput)
-    expect(Transaction).toHaveBeenCalledWith({
+    expect(createTransaction).toHaveBeenCalledWith({
       customerId: fakeInput.customerId,
       amount: fakeInput.amount,
       description: fakeInput.description,


### PR DESCRIPTION
Aqui utilizei o padrão [Factory](https://refactoring.guru/pt-br/design-patterns/builder) para permitir que façamos a inversão de dependência do caso de uso com a entidade de domínio. Foi a forma mais simples que imaginei para resolver nosso problema com o mock. 
Com a factory, foi só criar um mock com a mesma implementação para assim conseguir utilizar o spy sem mais problemas. Acabei inclusive pegando um bug no proceso. 

P.S.: Poderia ter utilizado o método estático na própria entidade, mas acredito que o problema seria parecido para mockar a classe.